### PR TITLE
feat(typst): Start migration to Typst 0.12

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Build Thesis
-      - run: nix -Lv develop .#deafult --command typst compile ./template/thesis.typ thesis.pdf --root "./"
+        run: nix -Lv develop .#deafult --command typst compile ./template/thesis.typ thesis.pdf --root "./"
       - name: Upload Release Asset - Assignment
         id: upload
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Build Thesis
-        run: nix -Lv develop .#deafult --command typst compile ./template/thesis.typ thesis.pdf --root "./"
+        run: nix -Lv develop .#default --command typst compile ./template/thesis.typ thesis.pdf --root "./"
       - name: Upload Release Asset - Assignment
         id: upload
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/github-workflow.json
 name: Build thesis
 
 on:
@@ -8,7 +9,7 @@ permissions:
   pull-requests: write
 
 jobs:
-  build_release_thesis:
+  build-nix:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -16,12 +17,13 @@ jobs:
         with:
           fetch-depth: '0'
           lfs: true
-
-      - uses: typst-community/setup-typst@v3
-      - run: typst compile ./template/thesis.typ thesis.pdf --root "./"
-      # NOTE: Update proposal.typ and comment out the following line if you want to build the proposal.
-      # - run: typst compile proposal.typ proposal.pdf
-      
+      - name: Install Nix
+        uses: cachix/install-nix-action@V28
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Build Thesis
+      - run: nix -Lv develop .#deafult --command typst compile ./template/thesis.typ thesis.pdf --root "./"
       - name: Upload Release Asset - Assignment
         id: upload
         uses: actions/upload-artifact@v4
@@ -31,11 +33,10 @@ jobs:
           path: ./thesis.pdf
           name: thesis.pdf
           retention-days: 5
-          
       - name: Comment PR Link
         uses: thollander/actions-comment-pull-request@v3
         with:
           reactions: eyes, rocket
-          comment_tag: file-upload
+          comment-tag: file-upload
           message: |
             Thank you for your contribution. Review ready at: ${{ steps.upload.outputs.artifact-url }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,5 @@
-name: Build and release thesis
+# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/github-workflow.json
+name: Build and Release thesis
 
 on:
   push:
@@ -17,13 +18,18 @@ jobs:
         with:
           fetch-depth: '0'
           lfs: true
-
+      - name: Install Nix
+        uses: cachix/install-nix-action@V28
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Build Thesis
+      - run: nix -Lv develop .#deafult --command typst compile ./template/thesis.typ thesis.pdf --root "./"
       - name: Create initial tag
         run: |
           if [ -z "$(git tag -l 'v*')" ]; then
             git tag v0.0.0
           fi
-
       - name: Bump version and push tag
         id: bump
         uses: anothrNick/github-tag-action@1.71.0
@@ -31,12 +37,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
           DEFAULT_BUMP: 'patch'
-
-      - uses: typst-community/setup-typst@v3
-      - run: typst compile ./template/thesis.typ thesis.pdf --root "./"
-      # NOTE: Add back proposal.typ when ready
-      # - run: typst compile proposal.typ proposal.pdf
-
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2
@@ -45,6 +45,5 @@ jobs:
           name: Version ${{ steps.bump.outputs.new_tag }}
           draft: false
           prerelease: false
-          # NOTE: Add back proposal.pdf when ready
           files: |
             thesis.pdf

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Build Thesis
-        run: nix -Lv develop .#deafult --command typst compile ./template/thesis.typ thesis.pdf --root "./"
+        run: nix -Lv develop .#default --command typst compile ./template/thesis.typ thesis.pdf --root "./"
       - name: Create initial tag
         run: |
           if [ -z "$(git tag -l 'v*')" ]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Build Thesis
-      - run: nix -Lv develop .#deafult --command typst compile ./template/thesis.typ thesis.pdf --root "./"
+        run: nix -Lv develop .#deafult --command typst compile ./template/thesis.typ thesis.pdf --root "./"
       - name: Create initial tag
         run: |
           if [ -z "$(git tag -l 'v*')" ]; then

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Port of the [uit-thesis](https://github.com/egraff/uit-thesis)-latex template to
 Using the Typst Universe package/template:
 
 ```console
-typst init @preview/modern-uit-thesis:0.1.1
+typst init @preview/modern-uit-thesis:0.1.2
 ```
 
 ### Fonts
@@ -45,8 +45,8 @@ If you're running typst locally, install the fonts in a directory of your choosi
 - [ ] Good examples
   - [x] Use of figures, tables, code blocks
     - [x] Side by side
-    - [ ] Create table from CSV
-    - [ ] Codeblocks with External Code
+    - [x] Create table from CSV
+    - [x] Codeblocks with External Code
   - [x] Citations
   - [x] Lists (unordered, ordered)
   - [x] Equations

--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
         "type": "github"
       },
       "original": {
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723637854,
-        "narHash": "sha256-med8+5DSWa2UnOqtdICndjDAEjxr5D7zaIiK4pn0Q7c=",
+        "lastModified": 1729070438,
+        "narHash": "sha256-KOTTUfPkugH52avUvXGxvWy8ibKKj4genodIYUED+Kc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c3aa7b8938b17aebd2deecf7be0636000d62a2b9",
+        "rev": "5785b6bb5eaae44e627d541023034e1601455827",
         "type": "github"
       },
       "original": {
@@ -97,11 +97,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1724857454,
-        "narHash": "sha256-Qyl9Q4QMTLZnnBb/8OuQ9LSkzWjBU1T5l5zIzTxkkhk=",
+        "lastModified": 1729104314,
+        "narHash": "sha256-pZRZsq5oCdJt3upZIU4aslS9XwFJ+/nVtALHIciX/BI=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "4509ca64f1084e73bc7a721b20c669a8d4c5ebe6",
+        "rev": "3c3e88f0f544d6bb54329832616af7eb971b6be6",
         "type": "github"
       },
       "original": {
@@ -176,11 +176,11 @@
     "typst-packages": {
       "flake": false,
       "locked": {
-        "lastModified": 1725384407,
-        "narHash": "sha256-5vBt3AZnuaieoIKhqbhSbkYgnLjX2kaQ1uchaoFKIpI=",
+        "lastModified": 1729252723,
+        "narHash": "sha256-xdaQYNw1GApaJnXJO4WnUTNuYeRXisxIUSuAzVXFEW4=",
         "owner": "typst",
         "repo": "packages",
-        "rev": "e247246ba19e2277d8493ce65ec4b0c09f90aa54",
+        "rev": "9bcf190c85da91be6df9f5fc25a93ce5812489cc",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729070438,
-        "narHash": "sha256-KOTTUfPkugH52avUvXGxvWy8ibKKj4genodIYUED+Kc=",
+        "lastModified": 1729413321,
+        "narHash": "sha256-I4tuhRpZFa6Fu6dcH9Dlo5LlH17peT79vx1y1SpeKt0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5785b6bb5eaae44e627d541023034e1601455827",
+        "rev": "1997e4aa514312c1af7e2bda7fad1644e778ff26",
         "type": "github"
       },
       "original": {
@@ -176,11 +176,11 @@
     "typst-packages": {
       "flake": false,
       "locked": {
-        "lastModified": 1729252723,
-        "narHash": "sha256-xdaQYNw1GApaJnXJO4WnUTNuYeRXisxIUSuAzVXFEW4=",
+        "lastModified": 1729608754,
+        "narHash": "sha256-iJkICZYj4BcRAHfXbXcYyLh3RO+oyICR1eMOXWyWufU=",
         "owner": "typst",
         "repo": "packages",
-        "rev": "9bcf190c85da91be6df9f5fc25a93ce5812489cc",
+        "rev": "8feafc65720edaf3a85105c3cb94c9ab039925c2",
         "type": "github"
       },
       "original": {

--- a/lib.typ
+++ b/lib.typ
@@ -35,9 +35,9 @@
 #let fill-line(left-text, right-text) = [#left-text #h(1fr) #right-text]
 
 // Helper to display external codeblocks.
-//·Based·on·https://github.com/typst/typst/issues/1494
-#let code-block(filename) = raw(
-  read(filename),
+// Based on https://github.com/typst/typst/issues/1494
+#let code-block(filename, content) = raw(
+  content,
   block: true,
   lang: filename.split(".").at(-1),
 )
@@ -275,11 +275,14 @@
   )
 
   // Configure paragraph properties.
-  // Default leading is 0.65em.
-  set par(leading: 0.7em, justify: true, linebreaks: "optimized")
-
-  // Default spacing is 1.2em.
-  show par: set block(spacing: 1.35em)
+  // Default leading is 0.7em.
+  // Default spacing is 1.35em.
+  set par(
+    leading: 0.7em,
+    justify: true,
+    linebreaks: "optimized",
+    spacing: 1.35em,
+  )
 
   // Add some vertical spacing for all headings
   show heading: it => {

--- a/template/chapters/figures.typ
+++ b/template/chapters/figures.typ
@@ -193,6 +193,12 @@ Codly also allows us to highlight code using line and column positions. @raw:pyt
 
 ] <raw:python>
 
+Code snippets can also be imported from files using the `code-block` macro. @raw:fsharp-file shows a F\# snippet imported from a file.
+
+#figure(caption: [F\# snippet imported from file], kind: raw)[
+  #code-block("Program.fsx", read("../code-snippets/Program.fsx"))
+] <raw:fsharp-file>
+
 // TODO: Make subfigures without subpar or figure out how to fix numbering
 == Subfigures <subsec:subfigures>
 A lot of times we want to display figures side by side and be able to reference them separately as well as together. To make this process easy, this thesis template includes the *subpar* #footnote[see #link("https://typst.app/universe/package/subpar")] package. It lets us easily lay out figures in a _grid_ while making all labels available for reference.
@@ -269,6 +275,19 @@ We can include as many figures as we want in the grid, and even mix and match fi
 ) <fig:uit_aurora>
 
 Another handy function available in this template is the `#dynamic-caption()`, which takes two arguments: a short and a long version of a caption. The long version is displayed under the figure, like in @fig:uit_aurora, however the short version is used in the List of Figures at the start of the thesis.
+
+Using the custom macro `csv-table` it is possible to include data dynamically for csv files. @table:csv-table demonstrates this.
+
+#figure(
+  csv-table(
+    tabledata: csv("../figures/table.csv"),
+    header-row: white,
+    odd-row: luma(240),
+    even-row: white,
+    columns: 3,
+  ),
+  caption: [A table with data from a csv file],
+) <table:csv-table>
 
 == Equations <subsec:equations>
 Typst has great built-in support for mathematical equations and this template applies numbering to them by default, so that we can refer to @equ:simple-equation just like we would a figure.

--- a/template/code-snippets/Program.fsx
+++ b/template/code-snippets/Program.fsx
@@ -1,0 +1,23 @@
+open System
+
+let cowsay (message: string) =
+    let messageLength = message.Length
+    let border = String.replicate (messageLength + 2) "-"
+    let cow = @"
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
+    "
+    printfn $" {border}"
+    printfn $"< {message} >"
+    printfn $" {border}"
+    printfn $"{cow}"
+
+[<EntryPoint>]
+let main argv =
+    printf "Enter a message: "
+    let input = Console.ReadLine()
+    cowsay input
+    0

--- a/template/figures/table.csv
+++ b/template/figures/table.csv
@@ -1,0 +1,4 @@
+Column 1,Column 2,Column 3
+Value 1A,Value 1B,Value 1C
+Value 2A,Value 2B,Value 2C
+Value 3A,Value 3B,Value 3C

--- a/typst.toml
+++ b/typst.toml
@@ -1,7 +1,7 @@
 [package]
 name = "modern-uit-thesis"
-version = "0.1.1"
-compiler = "0.11.1"
+version = "0.1.2"
+compiler = "0.12.0"
 entrypoint = "lib.typ"
 authors = ["Moritz Jörg <@mrtz-j>", "Ole Tytlandsvik <@otytlandsvik>"]
 license = "MIT"


### PR DESCRIPTION
Make the template compatible with Typst `0.12.0` and add examples for the `csv-table` and `code-block` macros.

Closes #20 
Closes #19