### PR TITLE
feat: add feedback conversation support

### DIFF
--- a/template/utils/feedback.typ
+++ b/template/utils/feedback.typ
@@ -1,7 +1,12 @@
-#let feedback(
-  feedback: none,
-  response: none,
-) = {
+#let feedback(feedback: none, response: none, ..messages) = {
+  if (response != none and feedback == none) {
+    panic("Expected response to have a feedback message.")
+  }
+
+  if (feedback, response).all(x => x == none) and (messages.pos().len() == 0) {
+    panic("Feedback must either have a feedback message or a list of messages.")
+  }
+
   counter("feedback").step()
   rect(
     width: 100%,
@@ -14,10 +19,47 @@
       weight: 700,
       context (counter("feedback").display() + ". Feedback: "),
     )
-    #feedback
-    #if response != none {
+    #if (feedback != none) {
+      feedback
+    }
+
+    #if (response != none) {
       line(length: 100%, stroke: 0.5pt + blue)
       [#text(weight: 700, "Response: ") #response]
+    }
+
+    #if (messages.pos().len() != 0) {
+      for (i, message) in messages.pos().enumerate() {
+        // do not draw a line before the first message
+        if (calc.rem(i, 2) == 0) and (i != 0) {
+          line(length: 100%, stroke: 0.5pt + blue)
+        }
+
+        let (author, content, date) = message
+        let role = if calc.even(i) {
+          "Feedback"
+        } else {
+          "Response"
+        }
+        let color = if calc.even(i) {
+          blue.lighten(10%)
+        } else {
+          navy.lighten(10%)
+        }
+
+        block(
+          width: 100%,
+          fill: color.lighten(90%),
+          outset: 5pt,
+          radius: 3pt,
+        )[
+          #text(weight: 700, fill: color, role + " from " + author + ": ")
+          #content
+          #if date != none {
+            text(size: 0.8em, style: "italic")[ (#date)]
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
This PR adds simple conversation support for the feedback() utility function with a new ..messages argument sink.

The purpose is to handle feedback that may not be resolvable with only one answer and that instead require back-and-forths. This may also prove useful if there are several people reviewing the thesis that may want to add comments to an existing piece of feedback.

Here is how the proposed implementation looks like:

![](https://i.edoyen.com/ShareX/2024/10/M4Yrsm.png)

This PR does not break any previous usage of feedback() but simply adds a ..messages argument sink that takes dictionaries of messages like so:

```typ
#feedback(
  ("Reviewer A", "This section needs more clarity.", "2023-10-30"),
  (
    "Author",
    "I've added more examples to make it clearer.",
    "2023-10-31, 10:00AM",
  ),
  (
    "Reviewer B",
    "Could you please add figures?",
    "2023-10-31, 2:00PM",
  ),
  (
    "Author",
    "I'll add some in the next revision.",
    "2023-11-01, 9:00AM",
  ),
)
```

Where pos0 is author name, pos1 is message content and pos2 is date.

This also means that one can theoretically add a list of messages after the feedback and response arguments (even though I see little use in that).

If the idea seems good, we could think about specific improvements, e.g. define a unique for every author name to make it easier to read when there are several people commenting, among other things.