### PR TITLE
Create release on tag push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,11 @@ name: Build thesis
 
 on:
   pull_request:
+    paths:
+      - "assets/*"
+      - "module/*"
+      - "template/*"
+      - "lib.typ"
 
 permissions:
   contents: write
@@ -15,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: '0'
+          fetch-depth: "0"
           lfs: true
       - name: Install Nix
         uses: cachix/install-nix-action@v30

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,8 +3,8 @@ name: Build and Release thesis
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - "*"
 
 permissions:
   contents: write
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: '0'
+          fetch-depth: "0"
           lfs: true
       - name: Install Nix
         uses: cachix/install-nix-action@v30
@@ -25,24 +25,12 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Build Thesis
         run: nix -Lv build .#default
-      - name: Create initial tag
-        run: |
-          if [ -z "$(git tag -l 'v*')" ]; then
-            git tag v0.0.0
-          fi
-      - name: Bump version and push tag
-        id: bump
-        uses: anothrNick/github-tag-action@1.71.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WITH_V: true
-          DEFAULT_BUMP: 'patch'
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.bump.outputs.new_tag }}
-          name: Version ${{ steps.bump.outputs.new_tag }}
+          tag_name: ${{ github.ref_name }}
+          name: Version ${{ github.ref_name }}
           draft: false
           prerelease: false
           files: |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Port of the [uit-thesis](https://github.com/egraff/uit-thesis)-latex template to
 Using the Typst Universe package/template:
 
 ```bash
-typst init @preview/modern-uit-thesis:0.1.2
+typst init @preview/modern-uit-thesis:0.1.3
 ```
 
 ### Fonts

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modern-uit-thesis"
-version = "0.1.2"
+version = "0.1.3"
 compiler = "0.12.0"
 entrypoint = "lib.typ"
 authors = ["Moritz Jörg <@mrtz-j>", "Ole Tytlandsvik <@otytlandsvik>"]


### PR DESCRIPTION
Rather than automatically creating new tags on pushes to main, require manual tag pushes.
This allows us to work on the main branch between releases, and is a step towards auto releasing to typst packages.