### PR TITLE
fix(page-number): use grey page numbering everywhere

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -106,8 +106,28 @@
 
 // Common styles for front matter
 #let front-matter(body) = {
-  set page(numbering: "i")
-  counter(page).update(1)
+  set page(
+    numbering: "i",
+    // Only show numbering in footer when no chapter header is present
+    footer: context {
+      let page-number = here().page()
+      let chapters = heading.where(level: 1)
+      if query(chapters).any(it => it.location().page() == here().page()) {
+        align(
+          center,
+          text(
+            weight: "thin",
+            font: ("Open Sans", "Noto Sans"),
+            size: 8pt,
+            fill: uit-gray-color,
+            counter(page).display("i"),
+          ),
+        )
+      } else {
+        none
+      }
+    },
+  )
   set heading(numbering: none)
   show heading.where(level: 1): it => {
     it
@@ -125,7 +145,16 @@
     footer: context {
       let chapters = heading.where(level: 1)
       if query(chapters).any(it => it.location().page() == here().page()) {
-        align(center, counter(page).display())
+        align(
+          center,
+          text(
+            weight: "thin",
+            font: ("Open Sans", "Noto Sans"),
+            size: 8pt,
+            fill: uit-gray-color,
+            counter(page).display(),
+          ),
+        )
       } else {
         none
       }

--- a/lib.typ
+++ b/lib.typ
@@ -128,6 +128,7 @@
       }
     },
   )
+  counter(page).update(1)
   set heading(numbering: none)
   show heading.where(level: 1): it => {
     it


### PR DESCRIPTION
This PR makes numbers in the front matter also be coloured grey, and removes numbers on blank pages.