### PR TITLE
feat(page-break): place new chapters on odd pages

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -375,9 +375,6 @@
       counter(math.equation).update(0)
     }
 
-    // Start chapter headings on a new, odd-numbered page
-    pagebreak(weak: true, to: "odd")
-
     v(16%)
     if heading.numbering != none {
       stack(
@@ -413,6 +410,13 @@
     weight: "bold",
     hyphenate: false,
   )
+  show heading.where(level: 1): it => {
+    state("content.switch").update(false)
+    // Start chapter headings on a new, odd-numbered page
+    pagebreak(weak: true, to:"odd")
+    state("content.switch").update(true)
+    it
+  }
 
   set page(
     // Set page header
@@ -423,8 +427,12 @@
 
       // If the current page is the start of a chapter, don't show a header
       let chapters = heading.where(level: 1)
-      if query(chapters).any(it => it.location().page() == page-number) {
+      let is-start-chapter = query(chapters).any(it => it.location().page() == page-number)
+      if is-start-chapter {
         return []
+      }
+      if not state("content.switch", false).get() and not is-start-chapter {
+        return
       }
 
       // Find the chapter of the section we are currently in

--- a/lib.typ
+++ b/lib.typ
@@ -6,7 +6,7 @@
 
 #import "@preview/subpar:0.2.1"
 #import "@preview/physica:0.9.5": *
-#import "@preview/glossarium:0.5.4": make-glossary, register-glossary
+#import "@preview/glossarium:0.5.3": make-glossary, register-glossary
 #import "@preview/codly:1.2.0": *
 #import "@preview/ctheorems:1.1.3": *
 

--- a/lib.typ
+++ b/lib.typ
@@ -356,6 +356,10 @@
 
   // Style chapter headings
   show heading.where(level: 1): it => {
+    state("content.switch").update(false)
+    // Start chapter headings on a new, odd-numbered page
+    pagebreak(weak: true, to:"odd")
+    state("content.switch").update(true)
     set text(font: ("Open Sans", "Noto Sans"), weight: "bold", size: 24pt)
 
     let heading-number = if heading.numbering == none {
@@ -410,13 +414,6 @@
     weight: "bold",
     hyphenate: false,
   )
-  show heading.where(level: 1): it => {
-    state("content.switch").update(false)
-    // Start chapter headings on a new, odd-numbered page
-    pagebreak(weak: true, to:"odd")
-    state("content.switch").update(true)
-    it
-  }
 
   set page(
     // Set page header

--- a/lib.typ
+++ b/lib.typ
@@ -6,7 +6,7 @@
 
 #import "@preview/subpar:0.2.1"
 #import "@preview/physica:0.9.5": *
-#import "@preview/glossarium:0.5.3": make-glossary, register-glossary
+#import "@preview/glossarium:0.5.4": make-glossary, register-glossary
 #import "@preview/codly:1.2.0": *
 #import "@preview/ctheorems:1.1.3": *
 
@@ -128,7 +128,7 @@
       }
     },
   )
-  counter(page).update(1)
+  counter(page).update(0)
   set heading(numbering: none)
   show heading.where(level: 1): it => {
     it
@@ -161,7 +161,7 @@
       }
     },
   )
-  counter(page).update(1)
+  counter(page).update(0)
   counter(heading).update(0)
   set heading(numbering: "1.1")
   show heading.where(level: 1): it => {
@@ -375,8 +375,8 @@
       counter(math.equation).update(0)
     }
 
-    // Start chapter headings on a new page
-    pagebreak(weak: true)
+    // Start chapter headings on a new, odd-numbered page
+    pagebreak(weak: true, to: "odd")
 
     v(16%)
     if heading.numbering != none {


### PR DESCRIPTION
Both the typeset page numbers and the document page numbers should be odd at the start of new chapters.

Continuation of #61.