### PR TITLE
Link the files in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Port of the [uit-thesis](https://github.com/egraff/uit-thesis)-latex template to Typst.
 
-`thesis.typ` contains a full usage example, see `thesis.pdf` for a rendered pdf.
+[`thesis.typ`](template/thesis.typ) contains a full usage example, see [`thesis.pdf`](template/thesis.pdf) for a rendered pdf.
 
 ## Usage
 


### PR DESCRIPTION
Link the references to the usage example and the rendered pdf to the actual files, so that they can be quickly found in one click. The links should be relative to the repo.