### PR TITLE
chore: update versions and exclude utils

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,78 +1,79 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/github-workflow.json
-name: Build and Release thesis
+# # yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/github-workflow.json
+# name: Build and Release thesis
+#
+# on:
+#   push:
+#     tags:
+#       - "*"
+#
+# permissions:
+#   contents: write
+#
+# jobs:
+#   build_release_thesis:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - name: Checkout
+#         uses: actions/checkout@v4
+#         with:
+#           fetch-depth: "0"
+#           lfs: true
+#           path: thesis-template
+#       - name: Install Nix
+#         uses: cachix/install-nix-action@v31
+#         with:
+#           extra_nix_config: |
+#             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+#       - name: Build Thesis
+#         run: nix -Lv build thesis-template/#default
+#       - name: Create Release
+#         id: create_release
+#         uses: softprops/action-gh-release@v2
+#         with:
+#           tag_name: ${{ github.ref_name }}
+#           name: Version ${{ github.ref_name }}
+#           draft: false
+#           prerelease: false
+#           files: |
+#             thesis-template/result/thesis.pdf
+#       - name: Pull packages fork
+#         uses: actions/checkout@v4
+#         with:
+#           repository: "mrtz-j/packages"
+#           path: "packages-fork"
+#       - name: cd into fork
+#         run: |
+#           cd packages-fork
+#       - name: Sync with typst/packages
+#         uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
+#         with:
+#           upstream_repository: typst/packages
+#           upstream_branch: main
+#           target_branch: main
+#           git_pull_args: --ff-only
+#           target_repo_token: ${{ secrets.REPO_TOKEN }}
+#       - name: Move new version into fork
+#         run: |
+#           # Copy the repository to a packages directory with the new tag we just created
+#           NEW_FORK_DIR = "preview/modern-uit-thesis/${{ github.ref_name }}"
+#           mkdir $NEW_FORK_DIR
+#           cp -r ../thesis-template/* $NEW_FORK_DIR/
+#           cd $NEW_FORK_DIR
+#           # Remove PDF
+#           rm template/thesis.pdf
+#           # Insert new version number
+#           sd 'version = "[0-9]+\.[0-9]+\.[0-9]+"' 'version = \"${{ github.ref_name }}\"' typst.toml
+#           sd '#import "../../lib.typ": \*' '#import '@preview/modern-uit-thesis:${{ github.ref_name }}': *' global.typ README.md
+#           # cd back out
+#           cd -
+#       - name: Create branch for PR
+#         run: |
+#           git checkout -b modern-uit-thesis/v${{ github.ref_name }}
+#           git add preview/modern-uit-thesis/${{ github.ref_name }}
+#           git commit \
+#             -m "Add version ${{ github.ref_name }} of modern-uit-thesis"
+#             --author "Publish action <>"
+#           git push origin modern-uit-thesis/v${{ github.ref_name }}
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
 
-on:
-  push:
-    tags:
-      - "*"
-
-permissions:
-  contents: write
-
-jobs:
-  build_release_thesis:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: "0"
-          lfs: true
-          path: thesis-template
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
-        with:
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-      - name: Build Thesis
-        run: nix -Lv build thesis-template/#default
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ github.ref_name }}
-          name: Version ${{ github.ref_name }}
-          draft: false
-          prerelease: false
-          files: |
-            thesis-template/result/thesis.pdf
-      - name: Pull packages fork
-        uses: actions/checkout@v4
-        with:
-          repository: "mrtz-j/packages"
-          path: "packages-fork"
-      - name: cd into fork
-        run: |
-          cd packages-fork
-      - name: Sync with typst/packages
-        uses: aormsby/Fork-Sync-With-Upstream-action@v3.4
-        with:
-          upstream_repository: typst/packages
-          upstream_branch: main
-          target_branch: main
-          git_pull_args: --ff-only
-          target_repo_token: ${{ secrets.REPO_TOKEN }}
-      - name: Move new version into fork
-        run: |
-          # Copy the repository to a packages directory with the new tag we just created
-          NEW_FORK_DIR = "preview/modern-uit-thesis/${{ github.ref_name }}"
-          mkdir $NEW_FORK_DIR
-          cp -r ../thesis-template/* $NEW_FORK_DIR/
-          cd $NEW_FORK_DIR
-          # Remove PDF
-          rm template/thesis.pdf
-          # Insert new version number
-          sd 'version = "[0-9]+\.[0-9]+\.[0-9]+"' 'version = \"${{ github.ref_name }}\"' typst.toml
-          sd '#import "../../lib.typ": \*' '#import '@preview/modern-uit-thesis:${{ github.ref_name }}': *' global.typ README.md
-          # cd back out
-          cd -
-      - name: Create branch for PR
-        run: |
-          git checkout -b modern-uit-thesis/v${{ github.ref_name }}
-          git add preview/modern-uit-thesis/${{ github.ref_name }}
-          git commit \
-            -m "Add version ${{ github.ref_name }} of modern-uit-thesis"
-            --author "Publish action <>"
-          git push origin modern-uit-thesis/v${{ github.ref_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Port of the [uit-thesis](https://github.com/egraff/uit-thesis)-latex template to
 Using the Typst Universe package/template:
 
 ```bash
-typst init @preview/modern-uit-thesis:0.1.4
+typst init @preview/modern-uit-thesis:0.1.5
 ```
 
 ### Fonts
@@ -35,16 +35,6 @@ If you're running typst locally, install the fonts in a directory of your choosi
 ### Nix
 
 If you're using the nix package manager, simply run the provided dev shell. It includes all dependencies needed to write and build the document locally, including the main fonts.
-
-#### Publish
-
-To publish a new release use `typship` as following:
-
-```bash
-nix run .#typship -- publish universe
-```
-
-Requires an access token with permission for your fork of the typst pacakages repo.
 
 ## License
 

--- a/typst.toml
+++ b/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modern-uit-thesis"
-version = "0.1.4"
+version = "0.1.5"
 compiler = "0.13.0"
 entrypoint = "lib.typ"
 authors = ["Moritz Jörg <@mrtz-j>", "Ole Tytlandsvik <@otytlandsvik>"]
@@ -10,9 +10,14 @@ repository = "https://github.com/mrtz-j/typst-thesis-template"
 keywords = ["thesis", "master", "uit", "bachelor", "university"]
 categories = ["thesis"]
 exclude = [
+".git",
+".gitignore",
 ".github",
-"scripts",
-"Justfile",
+"nix",
+"flake.nix",
+"flake.lock",
+"garnix.yaml",
+"**/*.pdf",
 ]
 
 [template]


### PR DESCRIPTION
- bumped template versions from 0.1.4 to 0.1.5
- added most contributor utils to exclude list
- removed typship details from README, it's better off in a CONTRIBUTING.md in the future
- disabled ci workflow on tag push for now
  - we should create a simple workflow instead that `sed`'s out the version number, and keep running typship manually for deployment