### PR TITLE
fix(ci): only run release on semver tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ name: Build and Release thesis
 on:
   push:
     tags:
-      - "*"
+      - "*.*.*"
   check_suite:
     types: [completed]
 


### PR DESCRIPTION
Should avoid running the workflow when garnix pushes the `main` tag.