### PR TITLE
Fix/release semver 2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,9 +2,6 @@
 name: Build and Release thesis
 
 on:
-  push:
-    tags:
-      - "*.*.*"
   check_suite:
     types: [completed]
 
@@ -13,6 +10,8 @@ permissions:
 
 jobs:
   build_release_thesis:
+    # Ideally, we would regex for semver format, but not possible with gh workflows...
+    if: ${{ ! (github.ref_name == 'main') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,11 +24,17 @@ jobs:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Build Thesis
-        run: "nix -Lv build --accept-flake-config .#default"
+        run: nix -Lv build --accept-flake-config .#default
       - name: Bump Version
         run: |
           nix -Lv develop .#default -c sd 'version = "[0-9]+\.[0-9]+\.[0-9]+"' 'version = \"${{ github.ref_name }}\"' typst.toml
           nix -Lv develop .#default -c sd 'modern-uit-thesis:[0-9]+\.[0-9]+\.[0-9]+' 'modern-uit-thesis:${{ github.ref_name }}' README.md
+      - name: Commit Bumped Version
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git commit -am 'Automated version bump'
+          git push
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Yet another attempt at fixing the workflow triggers.

- Now, we trigger the job when garnix has completed, and simply cancel it if the tag is `main`.
- Also added a stage to commit the `sd`-ed version bumps to `origin.`