### PR TITLE
Add user input for front and backpage image + frontpage logo

### DIFF
--- a/lib.typ
+++ b/lib.typ
@@ -367,6 +367,15 @@
   abbreviations: none,
   // The content of your work.
   body,
+  // The image to use on the front page.
+  // If not provided, a default image will be used.
+  frontimage: none,
+  // The logo to use on the front page.
+  // If not provided, a default logo of UiT will be used.
+  frontlogo: none,
+  // The image to use on the back page.
+  // If not provided, a default image will be used.
+  backimage: none,
 ) = {
   // Set the document's metadata.
   set document(title: title, author: author, date: if date != none {
@@ -649,6 +658,8 @@
     department: department,
     major: major,
     date: date,
+    frontimage: frontimage,
+    frontlogo: frontlogo,
   )
 
   // Use front matter stylings
@@ -799,5 +810,5 @@
   appendix
 
   // Display back page
-  backpage()
+  backpage(backimage: backimage)
 }

--- a/modules/backpage.typ
+++ b/modules/backpage.typ
@@ -1,4 +1,4 @@
-#let backpage() = {
+#let backpage(backimage: none) = {
   set page(
     paper: "a4",
     margin: (left: 3mm, right: 3mm, top: 12mm, bottom: 12mm),
@@ -8,10 +8,13 @@
     number-align: center,
   )
 
+  let default-img = image("../assets/backpage.svg", width: 216mm, height: 303mm)
+  let page-img = if backimage != none { backimage } else { default-img }
+
   // --- Back Page ---
   place(
     bottom + center,
     dy: 27mm,
-    image("../assets/backpage.svg", width: 216mm, height: 303mm),
+    page-img,
   )
 }

--- a/modules/frontpage.typ
+++ b/modules/frontpage.typ
@@ -7,8 +7,18 @@
   department: "",
   major: "",
   date: none,
+  image: none,
+  logo: none,
 ) = {
   set document(title: title, author: author)
+
+  // Set default page image & logo; check for user input
+  let default-img = image("../assets/frontpage_full.svg", width: 216mm, height: 303mm)
+  let default-logo = image("../assets/logo.svg", width: 100%, height: 100%)
+
+  let page-img = if image != none { image } else { default-img }
+  let page-logo = if logo != none { logo } else { default-logo }
+
   page(
     paper: "a4",
     margin: (left: 3mm, right: 3mm, top: 12mm, bottom: 27mm),
@@ -18,7 +28,7 @@
     number-align: center,
     [
       #set text(font: ("Open Sans", "Noto Sans"))
-      #place(top + left, image("../assets/logo.svg", width: 100%, height: 100%))
+      #place(top + left, page-logo)
       // NOTE: We use negative alignment from the bottom here to align with the cover page svg
       // (rather than the top) in the event of the title breaking to a new line
       #place(
@@ -58,7 +68,7 @@
       #place(
         bottom + center,
         dy: 27mm,
-        image("../assets/frontpage_full.svg", width: 216mm, height: 303mm),
+        page-img,
       )
     ],
   )

--- a/modules/frontpage.typ
+++ b/modules/frontpage.typ
@@ -7,8 +7,8 @@
   department: "",
   major: "",
   date: none,
-  image: none,
-  logo: none,
+  frontimage: none,
+  frontlogo: none,
 ) = {
   set document(title: title, author: author)
 
@@ -16,8 +16,8 @@
   let default-img = image("../assets/frontpage_full.svg", width: 216mm, height: 303mm)
   let default-logo = image("../assets/logo.svg", width: 100%, height: 100%)
 
-  let page-img = if image != none { image } else { default-img }
-  let page-logo = if logo != none { logo } else { default-logo }
+  let page-img = if frontimage != none { frontimage } else { default-img }
+  let page-logo = if frontlogo != none { frontlogo } else { default-logo }
 
   page(
     paper: "a4",


### PR DESCRIPTION
These changes would add the ability for the user to set the front page and back page images, plus add their own logo to the front page. Related to issue #93 

The only issue (which should be indicated somewhere) is that the provided images and logo all need to be A4-sized (this is because I didn't want to mess up your original code too much), i.e., they need to be roughly in the same format as the default images.
